### PR TITLE
Add Datadog webhook to GitHub repo.

### DIFF
--- a/infrastructure/terraform/site.tf
+++ b/infrastructure/terraform/site.tf
@@ -5,6 +5,11 @@ variable "site_domain" {
   default = "rocdev.org"
 }
 
+variable "datadog_api_key_for_github" {
+  type    = "string"
+  default = ""
+}
+
 resource "github_repository" "app_repo" {
   name               = "rocdev"
   description        = "The future of RocDev."
@@ -17,4 +22,43 @@ resource "github_repository" "app_repo" {
   allow_squash_merge = false
   allow_rebase_merge = true
   private            = false
+}
+
+resource "github_repository_webhook" "datadog_webhook" {
+  name       = "web"
+  repository = "${github_repository.app_repo.name}"
+  active     = true
+
+  events = [
+    "commit_comment",
+    "create",
+    "delete",
+    "deployment",
+    "deployment_status",
+    "gollum",
+    "issue_comment",
+    "issues",
+    "label",
+    "member",
+    "milestone",
+    "page_build",
+    "project",
+    "project_card",
+    "project_column",
+    "public",
+    "pull_request",
+    "pull_request_review",
+    "pull_request_review_comment",
+    "push",
+    "release",
+    "repository",
+    "status",
+    "team_add"
+  ]
+
+  configuration {
+    url          = "https://app.datadoghq.com/intake/webhook/github?api_key=${var.datadog_api_key_for_github}"
+    content_type = "form"
+    insecure_ssl = false
+  }
 }

--- a/infrastructure/terraform/terraform.tfstate
+++ b/infrastructure/terraform/terraform.tfstate
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.10.7",
-    "serial": 2,
+    "serial": 6,
     "lineage": "6a3533c3-95e1-4c84-a634-b997aecea1b9",
     "modules": [
         {
@@ -34,6 +34,55 @@
                             "private": "false",
                             "ssh_clone_url": "git@github.com:585-software/rocdev.git",
                             "svn_url": "https://github.com/585-software/rocdev"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": ""
+                },
+                "github_repository_webhook.datadog_webhook": {
+                    "type": "github_repository_webhook",
+                    "depends_on": [
+                        "github_repository.app_repo"
+                    ],
+                    "primary": {
+                        "id": "16793863",
+                        "attributes": {
+                            "active": "true",
+                            "configuration.%": "3",
+                            "configuration.content_type": "form",
+                            "configuration.insecure_ssl": "0",
+                            "configuration.url": "https://app.datadoghq.com/intake/webhook/github?api_key=01ae7b11c768b7584607eb465e2d616e",
+                            "events.#": "24",
+                            "events.1001664029": "public",
+                            "events.1199160415": "pull_request_review_comment",
+                            "events.1336705922": "milestone",
+                            "events.1560172493": "repository",
+                            "events.1597642340": "push",
+                            "events.1794599988": "project_column",
+                            "events.1894054520": "member",
+                            "events.2063623452": "status",
+                            "events.2342231791": "pull_request",
+                            "events.2413224187": "create",
+                            "events.245846248": "label",
+                            "events.2655453981": "release",
+                            "events.2810837315": "team_add",
+                            "events.3043241469": "deployment_status",
+                            "events.3464159411": "pull_request_review",
+                            "events.3665657731": "issues",
+                            "events.3676376333": "page_build",
+                            "events.3943847358": "deployment",
+                            "events.3995571316": "gollum",
+                            "events.547011484": "commit_comment",
+                            "events.797266123": "project_card",
+                            "events.800313582": "project",
+                            "events.831264653": "issue_comment",
+                            "events.974290055": "delete",
+                            "id": "16793863",
+                            "name": "web",
+                            "repository": "rocdev",
+                            "url": "https://api.github.com/repos/585-software/rocdev/hooks/16793863"
                         },
                         "meta": {},
                         "tainted": false

--- a/infrastructure/terraform/terraform.tfstate.backup
+++ b/infrastructure/terraform/terraform.tfstate.backup
@@ -1,7 +1,7 @@
 {
     "version": 3,
     "terraform_version": "0.10.7",
-    "serial": 2,
+    "serial": 6,
     "lineage": "6a3533c3-95e1-4c84-a634-b997aecea1b9",
     "modules": [
         {
@@ -23,12 +23,13 @@
                             "description": "The future of RocDev.",
                             "full_name": "585-software/rocdev",
                             "git_clone_url": "git://github.com/585-software/rocdev.git",
-                            "has_downloads": "true",
+                            "has_downloads": "false",
                             "has_issues": "true",
-                            "has_wiki": "true",
-                            "homepage_url": "",
+                            "has_wiki": "false",
+                            "homepage_url": "https://rocdev.org",
                             "http_clone_url": "https://github.com/585-software/rocdev.git",
                             "id": "rocdev",
+                            "license_template": "MIT",
                             "name": "rocdev",
                             "private": "false",
                             "ssh_clone_url": "git@github.com:585-software/rocdev.git",
@@ -38,7 +39,53 @@
                         "tainted": false
                     },
                     "deposed": [],
-                    "provider": "github"
+                    "provider": ""
+                },
+                "github_repository_webhook.datadog_webhook": {
+                    "type": "github_repository_webhook",
+                    "depends_on": [
+                        "github_repository.app_repo"
+                    ],
+                    "primary": {
+                        "id": "16793863",
+                        "attributes": {
+                            "active": "true",
+                            "configuration.%": "3",
+                            "configuration.content_type": "form",
+                            "configuration.insecure_ssl": "0",
+                            "configuration.url": "https://app.datadoghq.com/intake/webhook/github?api_key=01ae7b11c768b7584607eb465e2d616e",
+                            "events.#": "21",
+                            "events.1199160415": "pull_request_review_comment",
+                            "events.1336705922": "milestone",
+                            "events.1597642340": "push",
+                            "events.1794599988": "project_column",
+                            "events.1894054520": "member",
+                            "events.2063623452": "status",
+                            "events.2342231791": "pull_request",
+                            "events.2413224187": "create",
+                            "events.245846248": "label",
+                            "events.2655453981": "release",
+                            "events.2810837315": "team_add",
+                            "events.3043241469": "deployment_status",
+                            "events.3464159411": "pull_request_review",
+                            "events.3665657731": "issues",
+                            "events.3676376333": "page_build",
+                            "events.3943847358": "deployment",
+                            "events.547011484": "commit_comment",
+                            "events.797266123": "project_card",
+                            "events.800313582": "project",
+                            "events.831264653": "issue_comment",
+                            "events.974290055": "delete",
+                            "id": "16793863",
+                            "name": "web",
+                            "repository": "rocdev",
+                            "url": "https://api.github.com/repos/585-software/rocdev/hooks/16793863"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": ""
                 }
             },
             "depends_on": []


### PR DESCRIPTION
This adds all of the supported events. I'm fairly certain Datadog
ignores most of them, but I'd rather send them all and let the recipient
filter them down...for now.

Closes #14.