### PR TITLE
Change webhook Content-Type to json.

### DIFF
--- a/infrastructure/terraform/site.tf
+++ b/infrastructure/terraform/site.tf
@@ -60,7 +60,7 @@ resource "github_repository_webhook" "datadog_webhook" {
 
   configuration {
     url          = "https://app.datadoghq.com/intake/webhook/github?api_key=${var.datadog_api_key_for_github}"
-    content_type = "form"
+    content_type = "json"
     insecure_ssl = false
   }
 }


### PR DESCRIPTION
I guess Datadog wants JSON instead of form encoding.

Closes #22.