### PR TITLE
Support websocket for live reload

### DIFF
--- a/infrastructure/nginx/rocdev.vh.conf
+++ b/infrastructure/nginx/rocdev.vh.conf
@@ -20,6 +20,13 @@ server {
         proxy_pass http://backend;
     }
 
+    location /phoenix/live_reload/socket/websocket {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_pass http://backend;
+    }
+
     # redirect server error pages to the static page /50x.html
     #
     error_page   500 502 503 504  /50x.html;


### PR DESCRIPTION
Live reloading is accomplished with a websocket. That specific path is
now configured correctly.

Closes #31.